### PR TITLE
add TSPI in RSS list

### DIFF
--- a/.github/workflows/create-issue-rss.yml
+++ b/.github/workflows/create-issue-rss.yml
@@ -203,3 +203,14 @@ jobs:
           dry-run: "false"
           lastTime: "25h"
           labels: "BeyondTest,RSS"
+
+  TSPI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: guilhem/rss-issues-action@0.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          feed: "https://medium.com/feed/revista-tspi"
+          dry-run: "false"
+          lastTime: "25h"
+          labels: "TSPI,RSS"


### PR DESCRIPTION
## Description
Adicionando a revista https://medium.com/revista-tspi na lista de RSS

## Related Issue
N/A

## Motivation and Context
N/A

## How Has This Been Tested?
Verificar que os posts estão sendo gerados como issues

## Screenshots (if appropriate):
